### PR TITLE
refactor(auth): store JWT tokens in Http-Only cookies and standardize expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ I am excited to announce the first release of DawnPic, an open-source picture be
 
 ## v0.1.0
 
-- **(BREAKING CHANGE) Refactor Image Identification**: replace auto-incremented integer IDs with uuid.
+- **(BREAKING CHANGE) Refactor Image Identification**: Replaced auto-incremented integer IDs with UUID.
 
 ## v0.1.1
 
 - **Database Update via RESTful API**: Added support for updating the database using RESTful API endpoints, enabling seamless integration and data management.
-- **Web-Based Database Update**: Added support for updating the database via a web interface at the URL: `http(s):<domainName>:<port>/config/data-source/index.html`.
+- **Web-Based Database Update**: Added support for updating the database via a web interface at the URL: `http(s)://<domainName>:<port>/config/data-source/index.html`.
 
 ## v0.1.2
 
@@ -34,9 +34,11 @@ I am excited to announce the first release of DawnPic, an open-source picture be
 
 ## v0.2.0
 
-### Breaking Changes
-- **Image User Info**: The `Image` entity class has been refactored to include a new field, `userId`, which corresponds to the ID of the user. For anonymous users, this ID is set to `0`.
-
-### New Features
+- **(BREAKING CHANGE) Image User Info**: The `Image` entity class has been refactored to include a new field, `userId`, which corresponds to the ID of the user. For anonymous users, this ID is set to `0`.
 - **User Image Uploading**: The image uploading functionality has been refactored to record the `userId` in the image table. If an image is uploaded without a logged-in user, the `userId` will be set to `0`.
 - **User Image Information Retrieval**: Added support for retrieving information about images uploaded by a user through the `/api/userImages` endpoint. This API is accessible to logged-in users only.
+
+## v0.3.0
+
+- **(BREAKING CHANGE) Deprecating Returning JWT Token as Response**: JWT tokens are now stored in Http-Only cookies to prevent XSS attacks.
+- **Standard Token Expiration Time**: Standardized the JWT duration time to exactly one month (2,592,000 seconds). The duration time of the cookie is set to the same length.

--- a/README.md
+++ b/README.md
@@ -21,30 +21,10 @@
 
 - Java 17 or higher
 - MySQL database
-- Maven
 
-### Installation
+### Run
 
-1. **Clone the repository:**
-    ```bash
-    git clone https://github.com/hanyujie2002/DawnPic.git
-    cd DawnPic
-    ```
-
-2. **Configure the database:**
-   Update the `application.yaml` file with your MySQL database credentials.
-
-3. **Build the project:**
-    ```bash
-    mvn clean install
-    ```
-
-4. **Run the application:**
-    ```bash
-    mvn spring-boot:run
-    ```
-
-Alternatively, you can download the jar file directly from the [GitHub releases page](https://github.com/hanyujie2002/DawnPic/releases).
+Download the jar file from the [GitHub releases page](https://github.com/hanyujie2002/DawnPic/releases), run it via `java -jar <jar-name>`.
 
 ## Usage Instructions
 
@@ -54,7 +34,7 @@ To create a new account, use the `/signup` endpoint. Provide the necessary user 
 
 ### User Login
 
-Log in to your account using the `/login` endpoint. You will receive a token upon successful authentication.
+Log in to your account using the `/login` endpoint. Upon successful authentication, a JWT token will be stored in a Http-Only cookie.
 
 ### Current User Information
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.hanyujie</groupId>
     <artifactId>DawnPic</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <name>DawnPic</name>
     <description>DawnPic</description>
     <url/>
@@ -121,13 +121,13 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.springframework.boot</groupId>-->
-<!--                <artifactId>spring-boot-maven-plugin</artifactId>-->
-<!--                <configuration>-->
-<!--                    <executable>true</executable>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <executable>true</executable>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/hanyujie/dawnpic/config/SecurityConfig.java
+++ b/src/main/java/com/hanyujie/dawnpic/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                         .requestMatchers("/admin/**").hasAuthority(RoleEnum.ADMIN.getRole())
 
                         // user endpoints
+                        .requestMatchers("/api/userImages").hasAnyAuthority(RoleEnum.USER.getRole(), RoleEnum.ADMIN.getRole())
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/hanyujie/dawnpic/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hanyujie/dawnpic/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.hanyujie.dawnpic.jwt;
 import com.hanyujie.dawnpic.service.CustomUserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +41,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
             token = authorizationHeader.substring(7);
+        } else {
+            token = getValueFromCookies(request.getCookies(), "JWT_TOKEN");
+        }
+
+        if (token != null) {
             username = jwtUtil.getUsernameFromToken(token);
         }
 
@@ -61,5 +67,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private String getValueFromCookies(Cookie[] cookies, String tokenName) {
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(tokenName)) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/hanyujie/dawnpic/web/AuthController.java
+++ b/src/main/java/com/hanyujie/dawnpic/web/AuthController.java
@@ -1,20 +1,19 @@
 package com.hanyujie.dawnpic.web;
 
 import com.hanyujie.dawnpic.entity.AuthRequest;
-import com.hanyujie.dawnpic.entity.AuthResponse;
 import com.hanyujie.dawnpic.entity.User;
 import com.hanyujie.dawnpic.enums.RoleEnum;
 import com.hanyujie.dawnpic.jwt.JwtUtil;
 import com.hanyujie.dawnpic.service.CustomUserDetailsService;
 import com.hanyujie.dawnpic.service.UserService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,6 +27,7 @@ public class AuthController {
     private final JwtUtil jwtUtil;
     private final CustomUserDetailsService userDetailsService;
     private final UserService userService;
+    private final int MONTH_SECONDS = 2_592_000;
 
     @Autowired
     public AuthController(AuthenticationManager authenticationManager, JwtUtil jwtUtil, CustomUserDetailsService userDetailsService, UserService userService) {
@@ -38,7 +38,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> createAuthenticationToken(@RequestBody AuthRequest authRequest) throws Exception {
+    public ResponseEntity<?> createAuthenticationToken(@RequestBody AuthRequest authRequest, HttpServletResponse response) throws Exception {
         try {
             authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(authRequest.getUsername(), authRequest.getPassword())
@@ -50,19 +50,31 @@ public class AuthController {
         final UserDetails userDetails = userDetailsService.loadUserByUsername(authRequest.getUsername());
         final String role = userDetails.getAuthorities().iterator().next().getAuthority();
         final String jwt = jwtUtil.generateToken(userDetails.getUsername(), role);
+        Cookie cookie = new Cookie("JWT_TOKEN", jwt);;
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(MONTH_SECONDS);
+        response.addCookie(cookie);
 
-        return ResponseEntity.ok(new AuthResponse(jwt));
+        return ResponseEntity.ok("Login successfully");
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<?> registerUser(@RequestBody AuthRequest authRequest) throws Exception {
+    public ResponseEntity<?> registerUser(@RequestBody AuthRequest authRequest, HttpServletResponse response) throws Exception {
         try {
             User newUser = new User();
             newUser.setUsername(authRequest.getUsername());
             newUser.setPassword(authRequest.getPassword());
 
             userService.saveUser(newUser);
-            return ResponseEntity.ok(new AuthResponse(jwtUtil.generateToken(authRequest.getUsername(), RoleEnum.USER.getRole())));
+            final String jwt = jwtUtil.generateToken(authRequest.getUsername(), RoleEnum.USER.getRole());
+            Cookie cookie = new Cookie("JWT_TOKEN", jwt);
+            cookie.setHttpOnly(true);
+            cookie.setPath("/");
+            cookie.setMaxAge(MONTH_SECONDS);
+            response.addCookie(cookie);
+
+            return ResponseEntity.ok("User registered successfully");
         } catch (Exception e) {
             return ResponseEntity.badRequest().body("User registration failed" + e.getMessage());
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,6 @@ spring:
     password: 123456
     driver-class-name: com.p6spy.engine.spy.P6SpyDriver
 
-
   servlet:
       multipart:
         enabled: true
@@ -34,7 +33,7 @@ server:
 
 jwt:
   secret: 3c588b9e-7834-4ff6-8269-78551b6c874b
-  expiration: 12000000
+  expiration: 2_592_000_000
 
 #debug: true
 


### PR DESCRIPTION
- BREAKING CHANGE: JWT tokens are now stored in Http-Only cookies to prevent XSS attacks.
- Standardized the JWT duration time to exactly one month (2,592,000 seconds). The duration time of the cookie is set to the same length.